### PR TITLE
Minor refactors and enhancements

### DIFF
--- a/src/main/java/com/tyro/oss/dbevolution/LiquibaseMigrationTestDefinition.java
+++ b/src/main/java/com/tyro/oss/dbevolution/LiquibaseMigrationTestDefinition.java
@@ -85,11 +85,11 @@ public abstract class LiquibaseMigrationTestDefinition {
     }
 
     protected void assertPreMigrationSchema(Database schema, Connection connection) {
-        throw new UnsupportedOperationException("You must override either assertPreMigrationSchema(Database) or assertPreMigrationSchema(Database, Connection)");
+        throw new UnsupportedOperationException("You must override assertPreMigrationSchema(Database, Connection)");
     }
 
     protected void assertPostMigrationSchema(Database schema, Connection connection) {
-        throw new UnsupportedOperationException("You must override either assertPostMigrationSchema(Database) or assertPostMigrationSchema(Database, Connection)");
+        throw new UnsupportedOperationException("You must override assertPostMigrationSchema(Database, Connection)");
     }
 
     protected void insertPreMigrationData(Connection connection) throws SQLException {

--- a/src/main/java/com/tyro/oss/dbevolution/assertions/ColumnAssert.java
+++ b/src/main/java/com/tyro/oss/dbevolution/assertions/ColumnAssert.java
@@ -40,9 +40,10 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ColumnAssert {
 
     private static final String ID_COLUMN_NAME = "id";
+    private static final Map<Class<?>, ColumnTypeAssertions> columnTypeAssertions = createTypeAssertions();
+
     private final TableAssert table;
     private final String name;
-    private final Map<Class<?>, ColumnTypeAssertions> columnTypeAssertions = new HashMap<>();
     private final Database schema;
     private NullCheckColumnType columnType;
     private boolean disableNullCheck;
@@ -51,7 +52,6 @@ public class ColumnAssert {
         this.schema = schema;
         this.table = tableAssert;
         this.name = columnName;
-        createTypeAssertions(schema);
     }
 
     private static void assertColumnSize(Database database, String tableName, String columnName, int columnSize) {
@@ -161,29 +161,35 @@ public class ColumnAssert {
         assertColumnScale(database, tableName, columnName, scale);
     }
 
-    private void createTypeAssertions(Database schema) {
-        columnTypeAssertions.put(Boolean.class, new BooleanColumnAssertions(schema));
-        columnTypeAssertions.put(Boolean.TYPE, new BooleanColumnAssertions(schema));
+    private static Map<Class<?>, ColumnTypeAssertions> createTypeAssertions() {
+        Map<Class<?>, ColumnTypeAssertions> columnTypeAssertions = new HashMap<>();
+        columnTypeAssertions.put(Boolean.class, new BooleanColumnAssertions());
+        columnTypeAssertions.put(Boolean.TYPE, new BooleanColumnAssertions());
         columnTypeAssertions.put(Character.class, new CharacterColumnAssertions(1));
         columnTypeAssertions.put(Character.TYPE, new CharacterColumnAssertions(1));
         columnTypeAssertions.put(Enum.class, new StandardEnumColumnAssertions());
-        columnTypeAssertions.put(Integer.class, new IntegerColumnAssertions(schema));
-        columnTypeAssertions.put(Integer.TYPE, new IntegerColumnAssertions(schema));
+        columnTypeAssertions.put(Integer.class, new IntegerColumnAssertions());
+        columnTypeAssertions.put(Integer.TYPE, new IntegerColumnAssertions());
         columnTypeAssertions.put(Double.class, new DoubleColumnAssertions());
         columnTypeAssertions.put(Double.TYPE, new DoubleColumnAssertions());
         columnTypeAssertions.put(Long.class, new LongColumnAssertions());
         columnTypeAssertions.put(Long.TYPE, new LongColumnAssertions());
         columnTypeAssertions.put(BigDecimal.class, new BigDecimalColumnAssertions());
-        columnTypeAssertions.put(YearMonth.class, new YearMonthColumnAssertions(schema));
+        columnTypeAssertions.put(YearMonth.class, new YearMonthColumnAssertions());
         columnTypeAssertions.put(LocalDate.class, new DateCompatibleColumnAssertions());
         columnTypeAssertions.put(LocalTime.class, new LocalTimeColumnAssertions());
         columnTypeAssertions.put(LocalDateTime.class, new DateTimeColumnAssertions());
         columnTypeAssertions.put(ZoneId.class, new ZoneIdColumnAssertions());
         columnTypeAssertions.put(String.class, new StandardStringColumnAssertions());
-        columnTypeAssertions.put(byte[].class, new BinaryColumnAssertions(schema));
+        columnTypeAssertions.put(byte[].class, new BinaryColumnAssertions());
         columnTypeAssertions.put(TinyIntType.class, new TinyIntColumnAssertions(3));
-        columnTypeAssertions.put(BlobType.class, new BlobColumnAssertions(schema));
-        columnTypeAssertions.put(ClobType.class, new ClobColumnAssertions(schema));
+        columnTypeAssertions.put(BlobType.class, new BlobColumnAssertions());
+        columnTypeAssertions.put(ClobType.class, new ClobColumnAssertions());
+        return columnTypeAssertions;
+    }
+
+    public static void setAssertionsForType(Class<?> type, ColumnTypeAssertions assertions) {
+        columnTypeAssertions.put(type, assertions);
     }
 
     public ColumnAssert isNotPresent() {
@@ -426,7 +432,7 @@ public class ColumnAssert {
 
     private static class IntegerColumnAssertions extends ColumnTypeAssertions {
 
-        IntegerColumnAssertions(Database schema) {
+        IntegerColumnAssertions() {
             super(Types.INTEGER, 10);
         }
 
@@ -593,17 +599,14 @@ public class ColumnAssert {
 
     private static class YearMonthColumnAssertions extends ColumnTypeAssertions {
 
-        private final Database schema;
-
-        YearMonthColumnAssertions(Database schema) {
+        YearMonthColumnAssertions() {
             super(Types.CHAR, 4);
-            this.schema = schema;
         }
 
         @Override
         protected void makeAssertions(Database schema, String tableName, String columnName) {
-            assertColumnIsType(this.schema, tableName, columnName, Types.CHAR);
-            assertColumnSize(this.schema, tableName, columnName, 4);
+            assertColumnIsType(schema, tableName, columnName, Types.CHAR);
+            assertColumnSize(schema, tableName, columnName, 4);
         }
     }
 
@@ -669,16 +672,13 @@ public class ColumnAssert {
 
     private static class ClobColumnAssertions extends ColumnTypeAssertions {
 
-        private Database schema;
-
-        ClobColumnAssertions(Database schema) {
+        ClobColumnAssertions() {
             super(Types.LONGVARCHAR);
-            this.schema = schema;
         }
 
         @Override
         protected void makeAssertions(Database schema, String tableName, String columnName) {
-            assertColumnIsType(this.schema, tableName, columnName, Types.LONGVARCHAR);
+            assertColumnIsType(schema, tableName, columnName, Types.LONGVARCHAR);
         }
     }
 
@@ -697,47 +697,38 @@ public class ColumnAssert {
 
     private static class BooleanColumnAssertions extends ColumnTypeAssertions {
 
-        private final Database schema;
-
-        BooleanColumnAssertions(Database schema) {
+        BooleanColumnAssertions() {
             super(Types.BIT, 1);
-            this.schema = schema;
         }
 
         @Override
         protected void makeAssertions(Database schema, String tableName, String columnName) {
-            assertColumnIsType(this.schema, tableName, columnName, Types.BIT);
-            assertColumnSize(this.schema, tableName, columnName, 1);
+            assertColumnIsType(schema, tableName, columnName, Types.BIT);
+            assertColumnSize(schema, tableName, columnName, 1);
         }
     }
 
     private static class BlobColumnAssertions extends ColumnTypeAssertions {
 
-        private Database schema;
-
-        BlobColumnAssertions(Database schema) {
+        BlobColumnAssertions() {
             super(Types.LONGVARBINARY);
-            this.schema = schema;
         }
 
         @Override
         protected void makeAssertions(Database schema, String tableName, String columnName) {
-            assertColumnIsType(this.schema, tableName, columnName, Types.LONGVARBINARY);
+            assertColumnIsType(schema, tableName, columnName, Types.LONGVARBINARY);
         }
     }
 
     private static class BinaryColumnAssertions extends ColumnTypeAssertions {
 
-        private Database schema;
-
-        BinaryColumnAssertions(Database schema) {
+        BinaryColumnAssertions() {
             super(Types.BINARY);
-            this.schema = schema;
         }
 
         @Override
         protected void makeAssertions(Database schema, String tableName, String columnName) {
-            assertColumnIsType(this.schema, tableName, columnName, Types.BINARY);
+            assertColumnIsType(schema, tableName, columnName, Types.BINARY);
         }
     }
 

--- a/src/main/java/com/tyro/oss/dbevolution/assertions/ColumnAssert.java
+++ b/src/main/java/com/tyro/oss/dbevolution/assertions/ColumnAssert.java
@@ -223,6 +223,11 @@ public class ColumnAssert {
         return this;
     }
 
+    public ColumnAssert supportsType(int sqlType) {
+        assertColumnIsType(schema, table.getName(), name, sqlType);
+        return this;
+    }
+
     public ColumnAssert supportsString(int minimalSize) {
         assert minimalSize >= DEFAULT_VARCHAR_MAX_LENGTH : "There is no storage saving in having a varchar less than 255 in length";
         TextualColumnAssertions textualColumnAssertions = TextualColumnAssertions.buildTextualColumnAssertions(schema).withMinimalSize(minimalSize).allowClobs().build();

--- a/src/main/java/com/tyro/oss/dbevolution/assertions/ColumnAssert.java
+++ b/src/main/java/com/tyro/oss/dbevolution/assertions/ColumnAssert.java
@@ -418,7 +418,7 @@ public class ColumnAssert {
             this.columnAssert = columnAssert;
         }
 
-        public ColumnAssert checkedBy(String developers) {
+        public ColumnAssert checkedBy(String... developers) {
             columnAssert.disableNullCheck = true;
             return this.columnAssert;
         }

--- a/src/main/java/com/tyro/oss/dbevolution/assertions/DataAssert.java
+++ b/src/main/java/com/tyro/oss/dbevolution/assertions/DataAssert.java
@@ -51,7 +51,7 @@ public class DataAssert {
         return this;
     }
 
-    public DataAssert hasRow(String columnName, String valueToMatch) throws SQLException {
+    public DataAssert hasRowWithValue(String columnName, String valueToMatch) throws SQLException {
         PreparedStatement statement;
         if (valueToMatch == null) {
             statement = connection.prepareStatement("select * from " + tableName + " where " + columnName + " IS NULL");

--- a/src/main/java/com/tyro/oss/dbevolution/assertions/PrivilegeAssert.java
+++ b/src/main/java/com/tyro/oss/dbevolution/assertions/PrivilegeAssert.java
@@ -38,6 +38,15 @@ public class PrivilegeAssert {
         this.connection = connection;
     }
 
+    public PrivilegeAssert hasPrivilege(String tableName, EnumSet<TablePrivilege> expectedPrivileges) {
+        try {
+            String schemaName = connection.getCatalog();
+            return hasPrivilege(schemaName, tableName, expectedPrivileges);
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to retrieve schema name", e);
+        }
+    }
+
     public PrivilegeAssert hasPrivilege(String schemaName, String tableName, EnumSet<TablePrivilege> expectedPrivileges) {
         Set<TablePrivilege> tablePrivileges = new HashSet<>();
         tablePrivileges.addAll(getDatabaseTablePrivileges(schemaName, username, host));

--- a/src/main/java/com/tyro/oss/dbevolution/assertions/TableAssert.java
+++ b/src/main/java/com/tyro/oss/dbevolution/assertions/TableAssert.java
@@ -195,11 +195,15 @@ public class TableAssert {
         return this;
     }
 
-    boolean isNewTable() {
+    public Database getSchema() {
+        return schema;
+    }
+
+    public boolean isNewTable() {
         return isNewTable;
     }
 
-    String getName() {
+    public String getName() {
         return name;
     }
 }


### PR DESCRIPTION
- Fix error message when implementing LiquibaseMigrationTestDefinition
- Overload hasPrivilege assertion to get schema name from connection
- Rename hasRow assertion to be more consistent
- Refactor checkedBy method to accept a list of developers
- Support custom types for column assertions
- Assert the raw SQL type of a column
- Expose fields for extension in TableAssert